### PR TITLE
Fixed requests to moneybutton.com paymails

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Paymail Client",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "jest --env=node",
+    "test:watch": "jest --watch --env=node",
     "doc": "documentation readme src/index.js --section=API",
     "lint": "standard --fix ."
   },

--- a/src/__tests/atfinder.int.test.js
+++ b/src/__tests/atfinder.int.test.js
@@ -1,3 +1,5 @@
+/* global expect it describe */
+
 const atfinder = require('../index')
 
 /*
@@ -9,44 +11,120 @@ This integration test suite uses real HTTPS requests. Thus, it will need to be u
 
 */
 
-const TYS_PUBKEY = '032a0e522c34060279995dd2bf698871fc6bd35ad4efc4423edd8903fb68c4052c'
+// const TYS_PUBKEY = '032a0e522c34060279995dd2bf698871fc6bd35ad4efc4423edd8903fb68c4052c'
 
 describe('atfinder', () => {
   it('getServerConfig', async () => {
     const result = await atfinder.getServerConfig('ty@tyweb.us')
-    expect(result).toEqual(expect.objectContaining({
-      bsvalias: '1.0',
-      capabilities: expect.objectContaining({
-        a9f510c16bde: 'https://dojo.babbage.systems/verifyPublicKeyForPaymail/{alias}@{domain.tld}/{pubkey}',
-        f12f968c92d6: 'https://dojo.babbage.systems/getAvatarForPaymail/{alias}@{domain.tld}',
-        pki: 'https://dojo.babbage.systems/getIdentityKeyForPaymail/{alias}@{domain.tld}'
+    expect(result).toEqual(
+      expect.objectContaining({
+        bsvalias: '1.0',
+        capabilities: expect.objectContaining({
+          '747a1532f8fd': {
+            '5ffa478a0102': {
+              changePaymail: 'https://dojo.babbage.systems/changePaymail',
+              createTransaction:
+                'https://dojo.babbage.systems/createTransaction',
+              dojoURL: 'https://dojo.babbage.systems',
+              getCurrentPaymails:
+                'https://dojo.babbage.systems/getCurrentPaymails',
+              getCurrentReceivePolicy:
+                'https://dojo.babbage.systems/getCurrentReceivePolicy',
+              getPendingTransactions:
+                'https://dojo.babbage.systems/getPendingTransactions',
+              getTotalOfAmounts:
+                'https://dojo.babbage.systems/getTotalOfAmounts',
+              getTotalOfUnspentOutputs:
+                'https://dojo.babbage.systems/getTotalOfUnspentOutputs',
+              getTransactionOutputs:
+                'https://dojo.babbage.systems/getTransactionOutputs',
+              getTransactions: 'https://dojo.babbage.systems/getTransactions',
+              processTransaction:
+                'https://dojo.babbage.systems/processTransaction',
+              setNameAndPhotoURL:
+                'https://dojo.babbage.systems/setNameAndPhotoURL',
+              setReceivePolicy: 'https://dojo.babbage.systems/setReceivePolicy',
+              updateOutpointStatus:
+                'https://dojo.babbage.systems/updateOutpointStatus',
+              updateTransactionStatus:
+                'https://dojo.babbage.systems/updateTransactionStatus',
+              version: '0.1'
+            },
+            '92be59b59616': {
+              paymentURL:
+                'https://dojo.babbage.systems/submitSPVTransaction/{alias}@{domain.tld}',
+              protocols: { '3241645161d8': true }
+            },
+            cc7e1ab66d10:
+              'https://dojo.babbage.systems/getCertifiedKey/{alias}@{domain.tld}',
+            initialRequest:
+              'https://dojo.babbage.systems/authrite/initialRequest'
+          },
+          f12f968c92d6:
+            'https://dojo.babbage.systems/getAvatarForPaymail/{alias}@{domain.tld}'
+        })
       })
-    }))
+    )
   })
-  it('getNameAndPhotoURL', async () => {
-    const result = await atfinder.getNameAndPhotoURL('ty@tyweb.us')
+  // it("getNameAndPhotoURL", async () => {
+  //   const result = await atfinder.getNameAndPhotoURL("ty@tyweb.us");
+  //   expect(result).toEqual({
+  //     name: "Ty Everett",
+  //     photoURL: "https://tyweb.us/ty.jpg",
+  //   });
+  // });
+  // it("getIdentityKeyForPaymail", async () => {
+  //   const result = await atfinder.getIdentityKeyForPaymail("ty@tyweb.us");
+  //   expect(result).toEqual({
+  //     bsvalias: "1.0",
+  //     handle: "ty@tyweb.us",
+  //     pubkey: TYS_PUBKEY,
+  //   });
+  // });
+  // it("verifyPublicKeyForPaymail", async () => {
+  //   const result = await atfinder.verifyPublicKeyForPaymail(
+  //     "ty@tyweb.us",
+  //     TYS_PUBKEY
+  //   );
+  //   expect(result).toEqual({
+  //     handle: "ty@tyweb.us",
+  //     match: true,
+  //     pubkey: TYS_PUBKEY,
+  //   });
+  // });
+  it('moneybutton.com getNameAndPhotoURL', async () => {
+    const result = await atfinder.getNameAndPhotoURL('1@moneybutton.com')
     expect(result).toEqual({
-      name: 'Ty Everett',
-      photoURL: 'https://tyweb.us/ty.jpg'
+      avatar:
+        'https://www.gravatar.com/avatar/5d354bfcf442c94d3b16fc5065f22eb0?d=identicon',
+      name: 'Name'
     })
   })
-  it('getIdentityKeyForPaymail', async () => {
-    const result = await atfinder.getIdentityKeyForPaymail('ty@tyweb.us')
+  it('handcash.io getNameAndPhotoURL', async () => {
+    const result = await atfinder.getNameAndPhotoURL('alex@handcash.io')
+    expect(result).toEqual({
+      avatar: 'https://cloud.handcash.io/v2/users/profilePicture/alex',
+      name: 'Alex'
+    })
+  })
+  it('relayx.io getIdentityKeyForPaymail', async () => {
+    const result = await atfinder.getIdentityKeyForPaymail('jack@relayx.io')
     expect(result).toEqual({
       bsvalias: '1.0',
-      handle: 'ty@tyweb.us',
-      pubkey: TYS_PUBKEY
+      handle: 'jack@relayx.io',
+      pubkey:
+        '02c53a88890ed8cb23fe14174b5aab3494ad76285fa6be8ecc4369870826a7109a'
     })
   })
-  it('verifyPublicKeyForPaymail', async () => {
-    const result = await atfinder.verifyPublicKeyForPaymail(
-      'ty@tyweb.us',
-      TYS_PUBKEY
+  it('canonic.xyz getIdentityKeyForPaymail', async () => {
+    const result = await atfinder.getIdentityKeyForPaymail(
+      'canonic@canonic.xyz'
     )
     expect(result).toEqual({
-      handle: 'ty@tyweb.us',
-      match: true,
-      pubkey: TYS_PUBKEY
+      bsvalias: '1.0',
+      handle: 'canonic@canonic.xyz',
+      pubkey:
+        '0271d0234990c987cce5776efba77443dea90b7d285a73aeb75a8a9b52cc1bdf5a'
     })
   })
 })

--- a/src/__tests/atfinder.unit.test.js
+++ b/src/__tests/atfinder.unit.test.js
@@ -1,3 +1,5 @@
+/* global expect it describe jest beforeEach afterEach */
+
 const atfinder = require('../index')
 const axios = require('axios')
 
@@ -19,14 +21,14 @@ const VALID_BSVALIAS = {
       f12f968c92d6: 'f12f968c92d6/{alias}@{domain.tld}',
       pki: 'pki/{alias}@{domain.tld}',
       e70928472537: 'e70928472537/{alias}@{domain.tld}',
-      "747a1532f8fd": {
-        "initialRequest": "/authrite/initialRequest",
-        "cc7e1ab66d10": "/getCertifiedKey/{alias}@{domain.tld}",
-        "92be59b59616": {
-          "protocols": {
-            "3241645161d8": true
+      '747a1532f8fd': {
+        initialRequest: '/authrite/initialRequest',
+        cc7e1ab66d10: '/getCertifiedKey/{alias}@{domain.tld}',
+        '92be59b59616': {
+          protocols: {
+            '3241645161d8': true
           },
-          "paymentURL": "/submitSPVTransaction/{alias}@{domain.tld}"
+          paymentURL: '/submitSPVTransaction/{alias}@{domain.tld}'
         }
       }
     }
@@ -35,7 +37,8 @@ const VALID_BSVALIAS = {
 
 describe('atfinder', () => {
   beforeEach(() => {
-    axios.get.mockReturnValueOnce(VALID_DNS_RESPONSE)
+    axios.get
+      .mockReturnValueOnce(VALID_DNS_RESPONSE)
       .mockReturnValueOnce(VALID_BSVALIAS)
   })
   afterEach(() => {
@@ -45,7 +48,9 @@ describe('atfinder', () => {
     const result = await atfinder.getServerConfig('ty@tyweb.us')
     expect(result).toEqual(VALID_BSVALIAS.data)
     expect(axios.get.mock.calls).toEqual([
-      ['https://dns.google.com/resolve?name=_bsvalias._tcp.tyweb.us&type=SRV&cd=0'],
+      [
+        'https://dns.google.com/resolve?name=_bsvalias._tcp.tyweb.us&type=SRV&cd=0'
+      ],
       ['https://mock.host/.well-known/bsvalias']
     ])
   })
@@ -61,9 +66,7 @@ describe('atfinder', () => {
       name: 'Ty Everett',
       photoURL: 'MOCK_URL'
     })
-    expect(axios.get.mock.calls[2]).toEqual([
-      'f12f968c92d6/ty@tyweb.us'
-    ])
+    expect(axios.get.mock.calls[2]).toEqual(['f12f968c92d6/ty@tyweb.us'])
   })
   it('getIdentityKeyForPaymail', async () => {
     axios.get.mockReturnValueOnce({
@@ -71,9 +74,7 @@ describe('atfinder', () => {
     })
     const result = await atfinder.getIdentityKeyForPaymail('ty@tyweb.us')
     expect(result).toEqual('MOCK_GET_ID_KEY')
-    expect(axios.get.mock.calls[2]).toEqual([
-      'pki/ty@tyweb.us'
-    ])
+    expect(axios.get.mock.calls[2]).toEqual(['pki/ty@tyweb.us'])
   })
   it('verifyPublicKeyForPaymail', async () => {
     axios.get.mockReturnValueOnce({
@@ -108,12 +109,9 @@ describe('atfinder', () => {
     axios.post.mockReturnValueOnce({
       data: 'MOCK_SUBMIT_SPV'
     })
-    const result = await atfinder.submitSPVTransaction(
-      'ty@tyweb.us',
-      {
-        envelopeField: 'MOCK_VALUE'
-      }
-    )
+    const result = await atfinder.submitSPVTransaction('ty@tyweb.us', {
+      envelopeField: 'MOCK_VALUE'
+    })
     expect(result).toEqual('MOCK_SUBMIT_SPV')
     expect(axios.post.mock.calls[0]).toEqual([
       'e70928472537/ty@tyweb.us',
@@ -126,9 +124,12 @@ describe('atfinder', () => {
     const authriteClient = {
       request: jest.fn((url, config) => {
         return {
-          body: Buffer.from(JSON.stringify({
-            server: 'response'
-          }), 'utf8')
+          body: Buffer.from(
+            JSON.stringify({
+              server: 'response'
+            }),
+            'utf8'
+          )
         }
       })
     }
@@ -137,19 +138,21 @@ describe('atfinder', () => {
       authriteClient
     )
     expect(result).toEqual({ server: 'response' })
-    expect(authriteClient.request)
-      .toHaveBeenLastCalledWith(
-        '/getCertifiedKey/ty@tyweb.us',
-        { method: 'GET' }
-      )
+    expect(authriteClient.request).toHaveBeenLastCalledWith(
+      '/getCertifiedKey/ty@tyweb.us',
+      { method: 'GET' }
+    )
   })
   it('submitType42Payment', async () => {
     const authriteClient = {
       request: jest.fn((url, config) => {
         return {
-          body: Buffer.from(JSON.stringify({
-            server: 'response'
-          }), 'utf8')
+          body: Buffer.from(
+            JSON.stringify({
+              server: 'response'
+            }),
+            'utf8'
+          )
         }
       })
     }
@@ -159,11 +162,10 @@ describe('atfinder', () => {
       authriteClient
     )
     expect(result).toEqual({ server: 'response' })
-    expect(authriteClient.request)
-      .toHaveBeenLastCalledWith(
-        '/submitSPVTransaction/ty@tyweb.us',
-        { method: 'POST', body: { test: 'body' } }
-      )
+    expect(authriteClient.request).toHaveBeenLastCalledWith(
+      '/submitSPVTransaction/ty@tyweb.us',
+      { method: 'POST', body: { test: 'body' } }
+    )
   })
   it('deprecatedSubmitP2PTransaction', async () => {
     axios.post.mockReturnValueOnce({

--- a/src/getCertifiedKey.js
+++ b/src/getCertifiedKey.js
@@ -16,7 +16,7 @@ const getServerConfig = require('./getServerConfig')
 module.exports = async (paymail, authriteClient, config) => {
   const [alias, domain] = paymail.split('@')
   const serverConfig = await getServerConfig(paymail, config)
-  const url = serverConfig.capabilities['747a1532f8fd']['cc7e1ab66d10']
+  const url = serverConfig.capabilities['747a1532f8fd'].cc7e1ab66d10
     .replace('{alias}', alias)
     .replace('{domain.tld}', domain)
   const { body } = await authriteClient.request(url, { method: 'GET' })

--- a/src/getServerConfig.js
+++ b/src/getServerConfig.js
@@ -34,6 +34,7 @@ module.exports = async (
     hostDomain = hostDomain.substr(0, hostDomain.length - 1)
   } else {
     hostDomain = domain
+    if (hostDomain === 'moneybutton.com') hostDomain = 'www.moneybutton.com' // Browsers get CORS error on 302 redirect. Hard code this until moneybutton fixes it.
   }
 
   const { data: serverConfig } = await axios.get(

--- a/src/getServerConfig.js
+++ b/src/getServerConfig.js
@@ -21,15 +21,21 @@ module.exports = async (
   // Allow resolving Paymails when the server is running locally for testing
   if (domain === 'localhost' || domain.startsWith('localhost:')) {
     const { data: serverConfig } = await axios.get(
-    `http://${domain}/.well-known/bsvalias`
+      `http://${domain}/.well-known/bsvalias`
     )
     return serverConfig
   }
   const { data: dohResponse } = await axios.get(
     `${dohServer}?name=_bsvalias._tcp.${domain}&type=SRV&cd=0`
   )
-  let hostDomain = dohResponse.Answer[0].data.split(' ').pop()
-  hostDomain = hostDomain.substr(0, hostDomain.length - 1)
+  let hostDomain
+  if (dohResponse.Answer) {
+    hostDomain = dohResponse.Answer[0].data.split(' ').pop()
+    hostDomain = hostDomain.substr(0, hostDomain.length - 1)
+  } else {
+    hostDomain = domain
+  }
+
   const { data: serverConfig } = await axios.get(
     `https://${hostDomain}/.well-known/bsvalias`
   )


### PR DESCRIPTION
Moneybutton changed their domain SPV which broke all atfinder requests to moneybutton.com paymails. This PR fixes that (the code changes in: ./src/getServerConfig.js). Also updated the init.tests and ran `npm run lint`